### PR TITLE
openoffice style fix

### DIFF
--- a/src/OneSheet/Xml/StyleXml.php
+++ b/src/OneSheet/Xml/StyleXml.php
@@ -51,7 +51,7 @@ class StyleXml
     /**
      * Constant for cellXf style xml strings.
      */
-    const DEFAULT_XF_XML = '<xf numFmtId="0" fontId="%d" fillId="%d" borderId="%d"/>';
+    const DEFAULT_XF_XML = '<xf numFmtId="0" fontId="%d" fillId="%d" borderId="%d" applyFont="1" applyFill="1" applyBorder="1"/>';
 
     /**
      * Constant for the full style xml.


### PR DESCRIPTION
apparently i removed the apply* attributes at some point, which kills the styles in oo and libre.