### PR TITLE
add multi styles for rows to override cell styles

### DIFF
--- a/src/OneSheet/Sheet.php
+++ b/src/OneSheet/Sheet.php
@@ -156,11 +156,11 @@ class Sheet
      *
      * @return string
      */
-    public function addRow(array $row, Style $style)
+    public function addRow(array $row, $styles = null)
     {
         $columnCount = count($row);
         $this->updateMaxColumnCount($columnCount);
-        $cellXml = $this->getCellXml($row, $style);
+        $cellXml = $this->getCellXml($row, $styles);
 
         return $this->getRowXml($columnCount, $cellXml);
     }
@@ -196,13 +196,25 @@ class Sheet
      * @param Style $style
      * @return string
      */
-    private function getCellXml(array $row, Style $style)
+    private function getCellXml(array $row, $styles = null)
     {
         $cellXml = '';
+
+        if (!is_array($styles)) {
+            $style = $styles;
+        }
+
         foreach (array_values($row) as $cellIndex => $cellValue) {
+            if (is_array($styles) && isset($styles[$cellIndex])) {
+                $style = $styles[$cellIndex];
+            }
+
             $this->updateColumnWidths($cellValue, $cellIndex, $style->getFont());
+
+            $styleId = $style->getId();
+
             $cellXml .= $this->cellBuilder->build(
-                $this->rowIndex, $cellIndex, $cellValue, $style->getId()
+                $this->rowIndex, $cellIndex, $cellValue, $styleId
             );
         }
 

--- a/src/OneSheet/Sheet.php
+++ b/src/OneSheet/Sheet.php
@@ -209,9 +209,11 @@ class Sheet
                 $style = $styles[$cellIndex];
             }
 
-            $this->updateColumnWidths($cellValue, $cellIndex, $style->getFont());
+            if ($style) {
+                $this->updateColumnWidths($cellValue, $cellIndex, $style->getFont());
+            }
 
-            $styleId = $style->getId();
+            $styleId = $style ? $style->getId() : 0;
 
             $cellXml .= $this->cellBuilder->build(
                 $this->rowIndex, $cellIndex, $cellValue, $styleId

--- a/src/OneSheet/Writer.php
+++ b/src/OneSheet/Writer.php
@@ -145,9 +145,9 @@ class Writer
      * Add a single new row to the sheet and supply an optional style.
      *
      * @param array $row
-     * @param Style $style
+     * @param Style[] $styles
      */
-    public function addRow(array $row, $styles)
+    public function addRow(array $row, $styles = null)
     {
         if (!empty($row)) {
             foreach ($styles as $style) {

--- a/src/OneSheet/Writer.php
+++ b/src/OneSheet/Writer.php
@@ -147,13 +147,16 @@ class Writer
      * @param array $row
      * @param Style $style
      */
-    public function addRow(array $row, Style $style = null)
+    public function addRow(array $row, $styles)
     {
         if (!empty($row)) {
-            $style = $style instanceof Style ? $style : $this->styler->getDefaultStyle();
-            $this->styler->addStyle($style);
+            foreach ($styles as $style) {
+                $newStyle = $style instanceof Style ? $style : $this->styler->getDefaultStyle();
+                $this->styler->addStyle($newStyle);
+            }
+
             $this->sheetFiles[$this->currentSheet]->fwrite(
-                $this->sheets[$this->currentSheet]->addRow($row, $style)
+                $this->sheets[$this->currentSheet]->addRow($row, $styles)
             );
         }
     }


### PR DESCRIPTION
```
$columnColors = [];
$columnColors[] = [
    'bgColor' => 'E2EFDA'
];
$columnColors[] = [
    'bgColor' => 'FFF2CC'
];
$columnColors[] = [
    'bgColor' => 'FCE4D6'
];
$columnColors[] = [
    'bgColor' => 'DDEBF7'
];
$columnColors[] = [
    'bgColor' => 'D0CECE'
];

$rowStyles = [];

foreach ($columnColors as $column) {
    $rowStyle = new Style();

    if ($column['color']) {
        $rowStyle->setFontColor($column['color']);
    }

    if ($column['bgColor']) {
        $rowStyle->setFillColor($column['bgColor']);
    }

    $rowStyles[] = $rowStyle;
}

$onesheet->addRow($row, $rowStyles);
```