### PR TITLE
Implicitly marking parameter $style as nullable is deprecated

### DIFF
--- a/src/OneSheet/Writer.php
+++ b/src/OneSheet/Writer.php
@@ -130,7 +130,7 @@ class Writer
      * @param Style              $style
      * @throws \InvalidArgumentException
      */
-    public function addRows($rows, Style $style = null)
+    public function addRows($rows, ?Style $style = null)
     {
         if (!is_array($rows) && false === $rows instanceof \Traversable) {
             throw new \InvalidArgumentException('Expected array or traversable object as rows');
@@ -147,7 +147,7 @@ class Writer
      * @param array $row
      * @param Style $style
      */
-    public function addRow(array $row, Style $style = null)
+    public function addRow(array $row, ?Style $style = null)
     {
         if (!empty($row)) {
             $style = $style instanceof Style ? $style : $this->styler->getDefaultStyle();


### PR DESCRIPTION
Fix these:
Deprecated: OneSheet\Writer::addRows(): Implicitly marking parameter $style as nullable is deprecated, the explicit nullable type must be used instead in /onesheet/src/OneSheet/Writer.php on line 133 Deprecated: OneSheet\Writer::addRow(): Implicitly marking parameter $style as nullable is deprecated, the explicit nullable type must be used instead in /onesheet/src/OneSheet/Writer.php on line 150

(tested with PHP 8.4)